### PR TITLE
Feat/update event

### DIFF
--- a/src/components/Events/EditEvent.jsx
+++ b/src/components/Events/EditEvent.jsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 
 import Modal from "../UI/Modal.jsx";
 import EventForm from "./EventForm.jsx";
-import { fetchEvent, updateEvent } from "../../utils/http.js";
+import { fetchEvent, queryClient, updateEvent } from "../../utils/http.js";
 import LoadingIndicator from "../UI/LoadingIndicator.jsx";
 import ErrorBlock from "../UI/ErrorBlock.jsx";
 
@@ -18,6 +18,12 @@ export default function EditEvent() {
 
   const { mutate } = useMutation({
     mutationFn: updateEvent,
+    onMutate: async (data) => {
+      const newEvent = data.event;
+
+      await queryClient.cancelQueries({ queryKey: ["events", params.id] });
+      queryClient.setQueryData(["events", params.id], newEvent);
+    },
   });
 
   function handleSubmit(formData) {

--- a/src/components/Events/EditEvent.jsx
+++ b/src/components/Events/EditEvent.jsx
@@ -22,7 +22,19 @@ export default function EditEvent() {
       const newEvent = data.event;
 
       await queryClient.cancelQueries({ queryKey: ["events", params.id] });
+      const prevEvent = queryClient.getQueryData(["events", params.id]);
+
       queryClient.setQueryData(["events", params.id], newEvent);
+
+      return { prevEvent };
+    },
+
+    onError: (error, data, context) => {
+      queryClient.setQueryData(["events", params.id], context.prevEvent);
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries(["events", params.id]);
     },
   });
 

--- a/src/components/Events/EditEvent.jsx
+++ b/src/components/Events/EditEvent.jsx
@@ -1,9 +1,9 @@
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 import Modal from "../UI/Modal.jsx";
 import EventForm from "./EventForm.jsx";
-import { fetchEvent } from "../../utils/http.js";
+import { fetchEvent, updateEvent } from "../../utils/http.js";
 import LoadingIndicator from "../UI/LoadingIndicator.jsx";
 import ErrorBlock from "../UI/ErrorBlock.jsx";
 
@@ -16,7 +16,14 @@ export default function EditEvent() {
     queryFn: ({ signal }) => fetchEvent({ signal, id: params.id }),
   });
 
-  function handleSubmit(formData) {}
+  const { mutate } = useMutation({
+    mutationFn: updateEvent,
+  });
+
+  function handleSubmit(formData) {
+    mutate({ id: params.id, event: formData });
+    navigate("../");
+  }
 
   function handleClose() {
     navigate("../");

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -94,3 +94,22 @@ export async function deleteEvent({ id }) {
 
   return response.json();
 }
+
+export async function updateEvent({ id, event }) {
+  const response = await fetch(`http://localhost:3000/events/${id}`, {
+    method: "PUT",
+    body: JSON.stringify({ event }),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const error = new Error("An error has occurred while updating the event");
+    error.code = response.status;
+    error.info = await response.json();
+    throw error;
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
- Implemented **useMutation** to handle event updates with optimistic UI updates.
- Added **onMutate** to set the new event data and cache the previous event.
- Cancelled ongoing queries before mutation to ensure data consistency.
- Implemented **onError** to revert to the previous event state if mutation fails.
- Ensured cache is invalidated on mutation settlement for fresh data fetching.